### PR TITLE
two bug-fixes and new cli flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,31 @@ pip3 install --user jsonl-to-conll
 
 ## Usage
 ### Sample Usage
+Basic usage:
 ```bash
 jsonl-to-conll input.jsonl output.conll
 ```
 
+To specify a separator for the conll file and atypical names for the 'text' and 'label' json fields:
+```bash
+jsonl-to-conll input.jsonl output.conll -s $'\t' --text_field 'data' --label_field 'labels'
+```
+
 ### Documentation
 ```bash
-usage: jsonl-to-conll [-h] input_filename output_filename
-jsonl-to-conll: error: the following arguments are required: input_filename, output_filename
+usage: jsonl-to-conll [-h] [-s [SEPARATOR]] [--text_field [TEXT_FIELD]] [--label_field [LABEL_FIELD]] input_filename output_filename
+
+positional arguments:
+  input_filename        Input JSONL filename
+  output_filename       Output CONLL filename
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -s [SEPARATOR], --separator [SEPARATOR]
+                        Separator to use between words and tags
+  --text_field [TEXT_FIELD]
+                        Name of the JSON field the text is stored in
+  --label_field [LABEL_FIELD]
+                        Name of the JSON field the labels are stored in
+
 ```

--- a/README.rst
+++ b/README.rst
@@ -19,14 +19,39 @@ Usage
 Sample Usage
 ^^^^^^^^^^^^
 
+
+Basic usage:
+
 .. code-block:: bash
 
    jsonl-to-conll input.jsonl output.conll
+
+
+To specify a separator for the conll file and atypical names for the 'text' and 'label' json fields:
+
+.. code-block:: bash
+
+   jsonl-to-conll input.jsonl output.conll -s $'\t' --text_field 'data' --label_field 'labels'
+
+
 
 Documentation
 ^^^^^^^^^^^^^
 
 .. code-block:: bash
+  
+    usage: jsonl-to-conll [-h] [-s [SEPARATOR]] [--text_field [TEXT_FIELD]] [--label_field [LABEL_FIELD]] input_filename output_filename
+   
+   positional arguments:
+     input_filename        Input JSONL filename
+     output_filename       Output CONLL filename
+   
+   optional arguments:
+     -h, --help            show this help message and exit
+     -s [SEPARATOR], --separator [SEPARATOR]
+                           Separator to use between words and tags
+     --text_field [TEXT_FIELD]
+                           Name of the JSON field the text is stored in
+     --label_field [LABEL_FIELD]
+                           Name of the JSON field the labels are stored in
 
-   usage: jsonl-to-conll [-h] input_filename output_filename
-   jsonl-to-conll: error: the following arguments are required: input_filename, output_filename

--- a/jsonl_to_conll/cli.py
+++ b/jsonl_to_conll/cli.py
@@ -5,11 +5,14 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("input_filename", help="Input JSONL filename", type=str)
   parser.add_argument("output_filename", help="Output CONLL filename", type=str)
+  parser.add_argument("-s", "--separator", help="Separator to use between words and tags", type=str, default=' ', nargs='?')
+  parser.add_argument("--text_field", help="Name of the JSON field the text is stored in", type=str, default='text', nargs='?')
+  parser.add_argument("--label_field", help="Name of the JSON field the labels are stored in", type=str, default='label', nargs='?')
   args = parser.parse_args()
 
   data = io.read_jsonl(args.input_filename)
-  data = convert.flatten_all(data)
-  io.json_to_text(data, args.output_filename)
+  data = convert.flatten_all(data, args.text_field, args.label_field)
+  io.json_to_text(data, args.output_filename, args.separator)
 
 if __name__ == "__main__":
   main()

--- a/jsonl_to_conll/convert.py
+++ b/jsonl_to_conll/convert.py
@@ -1,13 +1,13 @@
 import json
 
 
-def flatten(data):
+def flatten(data, text_field, label_field):
   output_text = []
   beg_index = 0
   end_index = 0
 
-  text = data["text"]
-  all_labels = sorted(data["labels"])
+  text = data[text_field]
+  all_labels = sorted(data[label_field])
 
   for ind in range(len(all_labels)):
     next_label = all_labels[ind]
@@ -16,12 +16,12 @@ def flatten(data):
     label = next_label
     beg_index = label[0]
     end_index = label[1]
-    label_text = text[beg_index:end_index]
+    label_text = text[beg_index:end_index].strip()
     output_text += [(label_word, "B-" + label[2]) if not i else (label_word, "I-" + label[2]) for i, label_word in enumerate(label_text.split(" "))]
 
   output_text += [(label_word, "O") for label_word in text[end_index:].strip().split()]
   return output_text
 
 
-def flatten_all(datas):
-  return [flatten(data) for data in datas]
+def flatten_all(datas, text_field, label_field):
+  return [flatten(data, text_field, label_field) for data in datas]

--- a/jsonl_to_conll/io.py
+++ b/jsonl_to_conll/io.py
@@ -1,15 +1,12 @@
 import json
 
-def json_to_text(jsons, output_filename):
+def json_to_text(jsons, output_filename, separator):
   with open(output_filename, "w") as f:
     for each_json in jsons:
       for line in each_json:
-        f.writelines(" ".join(line) + "\n")
-      f.writelines("\n")
+        f.write(separator.join(line) + "\n")
+      f.write("\n")
 
 def read_jsonl(filename):
-  result = []
   with open(filename, "r") as f:
-    for line in f.readlines():
-      result.append(json.loads(line))
-  return result
+    return [json.loads(line) for line in f if line.strip()]


### PR DESCRIPTION
I fixed a bug creating empty labels when the span of the label specified in the json also spanned a leading space after a word. This happens a lot when people use a labeling software and don't notice they also selected a space after/before a word when tagging it. The fix was just adding a `.strip()` to the `label_text = text[beg_index:end_index]` in `convert.py`
For example, a json like this:
```json 
{"data": "James is a cool name .", "label": [[0, 6, "PER"]]}
```
would have been parsed as this:
```
James B-PER
 I-PER
is O
a O
cool O
name O
. O

```
but now is parsed as:
```
James B-PER
is O
a O
cool O
name O
. O

```

I also fixed a minor bug causing the JSON decoder to fail on empty lines in jsonl file. Even though regular jsonl files shouldn't contain empty lines, some do. These are usually introduced either as a result of some editors auto-adding a new line at the end of each file when saving or as a result of concatenation of multiple such files, I just rephrased `read_jsonl(filename)` in `cli.py` and added a condition.

I added cli flags to specify json field names for text and labels, as different labeling tools export jsonl files with different field names. And Lastly I also added a flag to choose a separator of words and tags in the conll file, as some parsers prefer different characters as separators.

Oh, and I also reflected the changes in the READMEs.

Now, you can process an `input.jsonl` file like this:
```jsonl
{"id": 0, "data": "James is a cool name .", "label": [[0, 6, "PER"]]}
{"id": 1, "data": "Facebook is a social network .", "label": [[0, 9, "ORG"]]}


```
(note: the new lines at the end, tagged sub-strings including trailing spaces, different name for text field)
by running
```bash
 jsonl-to-conll input.jsonl output.conll -s $'\t' --text_field 'data'
```
you generate a tab-separated `output.conll` file:
```
James	B-PER
is	O
a	O
cool	O
name	O
.	O

Facebook	B-ORG
is	O
a	O
social	O
network	O
.	O

```